### PR TITLE
Fix Codacy code coverage report from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,6 @@ env:
     - secure: "D34yO9PaPKzr9UVB7EUwmWi5cWMGU7+1JioSu3PDsO4QFyKnAqjkJxa/3JefmW/PYeTC/fCGv1F1pn+I+YnzF+Os6xpiHF9CxZ/BI2sJtKi4BOxs77fPJV55NrJJ9Kdffa3HsVIOxtJu0vS+eCMe7kfksKR2K2LwIMQ/eSF3PvM="
     - secure: "WhQ61s+PVsJXlB/zwEelg5dFqmcxFCNcxQUZ8cUAbpvfgZTltVekh6C1jct89dHfEPS2oZeuPQcBG2P0TrgvXGLiRE/b9JUPVZcvIazTOrXfA4PH0hWmJ9SYyV/XYQDtxzf4JYnB4C/s1qjhHgHUZJPoIhVgEVBy8pUPFX+EdFk="
 
-install:
-  - npm install codecov
-
 before_script:
   - npm install
 
@@ -24,7 +21,7 @@ script:
   - npm-check
 
 after_success:
-  - tap --coverage-report=lcov | codecov
+  - tap --coverage-report=text-lcov | codacy-coverage
   - 'curl -s http://google.com/ping\?sitemap=http:%3A%2F%2Fsigurdhsson.org%2Fsitemap.xml > /dev/null'
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ env:
     - secure: "D34yO9PaPKzr9UVB7EUwmWi5cWMGU7+1JioSu3PDsO4QFyKnAqjkJxa/3JefmW/PYeTC/fCGv1F1pn+I+YnzF+Os6xpiHF9CxZ/BI2sJtKi4BOxs77fPJV55NrJJ9Kdffa3HsVIOxtJu0vS+eCMe7kfksKR2K2LwIMQ/eSF3PvM="
     - secure: "WhQ61s+PVsJXlB/zwEelg5dFqmcxFCNcxQUZ8cUAbpvfgZTltVekh6C1jct89dHfEPS2oZeuPQcBG2P0TrgvXGLiRE/b9JUPVZcvIazTOrXfA4PH0hWmJ9SYyV/XYQDtxzf4JYnB4C/s1qjhHgHUZJPoIhVgEVBy8pUPFX+EdFk="
 
+install:
+  - npm install npm-check
+  - npm install codacy-coverage
+
 before_script:
   - npm install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ script:
   - npm-check
 
 after_success:
-  - tap --coverage-report=text-lcov | codacy-coverage
+  - tap --coverage-report=text-lcov | codacy-coverage --verbose
   - 'curl -s http://google.com/ping\?sitemap=http:%3A%2F%2Fsigurdhsson.org%2Fsitemap.xml > /dev/null'
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ env:
     - secure: "WhQ61s+PVsJXlB/zwEelg5dFqmcxFCNcxQUZ8cUAbpvfgZTltVekh6C1jct89dHfEPS2oZeuPQcBG2P0TrgvXGLiRE/b9JUPVZcvIazTOrXfA4PH0hWmJ9SYyV/XYQDtxzf4JYnB4C/s1qjhHgHUZJPoIhVgEVBy8pUPFX+EdFk="
 
 install:
-  - npm install npm-check
   - npm install codecov
 
 before_script:

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "broken-link-checker": "^0.7.4",
     "html5-lint": "^0.3.0",
     "jshint": "^2.9.4",
+    "npm-check": "^5.4.0",
     "tap": "^10.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,10 +33,8 @@
   "license": "MIT",
   "devDependencies": {
     "broken-link-checker": "^0.7.4",
-    "codacy-coverage": "^2.0.2",
     "html5-lint": "^0.3.0",
     "jshint": "^2.9.4",
-    "npm-check": "^5.4.0",
     "tap": "^10.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "license": "MIT",
   "devDependencies": {
     "broken-link-checker": "^0.7.4",
+    "codacy-coverage": "^2.0.2",
     "html5-lint": "^0.3.0",
     "jshint": "^2.9.4",
     "npm-check": "^5.4.0",


### PR DESCRIPTION
- [x] Use `codacy-coverage`
- [x] Use `text-lcov` output from `tap`
- [x] Define `CODACY_PROJECT_TOKEN` in `.travis.yml` (encrypted) (0729498)
- [x] Remove `CODACY_PROJECT_TOKEN` from Travis settings (0729498)
- [x] Remove `codecov.yaml` (32b3e6a)
- [x] Replace codecov.io badge with Codacy coverage badge (32b3e6a)