### PR TITLE
Reverse order of GitHub commits

### DIFF
--- a/callbacks.js
+++ b/callbacks.js
@@ -79,7 +79,7 @@ Callbacks.prototype.getGithubCommits = function (options) {
       return item.type == 'PushEvent';
     }).map(function (item) {
       var repo = item.repo.name;
-      return item.payload.commits.map(function (subitem) {
+      return item.payload.commits.reverse().map(function (subitem) {
         return {
           'sha': subitem.sha,
           'url': 'http://github.com/' + repo + '/commit/' + subitem.sha,


### PR DESCRIPTION
This makes the most recent commit in a set appear, instead of the
oldest one. Only makes a difference if multiple commits have been
pushed to a repository at the same time.