### PR TITLE
Only use subject line from recent commits

### DIFF
--- a/api/recent_commits.rb
+++ b/api/recent_commits.rb
@@ -19,7 +19,7 @@ module RecentCommits
           {
             sha: commit.sha,
             url: "http://github.com/#{event.repo.name}/commit/#{commit.sha}",
-            message: commit.message.split('\n')[0],
+            message: commit.message.split("\n").first,
             repo: event.repo.name,
             date: event.created_at
           }


### PR DESCRIPTION
The recent commits API script incorrectly used the whole commit
message since it did not split correctly on newlines.